### PR TITLE
Fix default option in --arch help

### DIFF
--- a/src/binbloom.c
+++ b/src/binbloom.c
@@ -1860,7 +1860,7 @@ void print_usage(char *program_name)
     printf("Quarkslab's Binbloom - Raw firmware analysis tool\n\n");
     printf("Binbloom searches for endianness, base addresses and UDS structures from raw firmware files.\n\n");
     printf(" Usage: %s [options] firmware_file\n", program_name);
-    printf("\t-a (--arch)\t\tSpecify target architecture, must be 32 or 64 (default: 64).\n");
+    printf("\t-a (--arch)\t\tSpecify target architecture, must be 32 or 64 (default: 32).\n");
     printf("\t-b (--base)\t\tSpecify base address to use for UDS structures search (optional).\n");
     printf("\t-e (-endian)\t\tSpecify the endianness of the provided file, must be 'le' (little endian) or 'be' (big endian) (optional).\n");
     printf("\t-d (--deep)\t\tEnable deep search (very slow)\n");


### PR DESCRIPTION
In Binbloom usage:
```
 Usage: binbloom [options] firmware_file
        -a (--arch)             Specify target architecture, must be 32 or 64 (default: 64).
```

It seems that default arch is 32-bit, not 64-bit.

Best regards and thank you for this tool,